### PR TITLE
change connect glusterd addr filter localhost (#4442)

### DIFF
--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -2830,7 +2830,10 @@ mgmt_rpc_notify(struct rpc_clnt *rpc, void *mydata, rpc_clnt_event_t event,
                         "Exhausted all volfile servers, Retrying from again!");
                 }
             } else {
-                server = list_entry(server->list.next, typeof(*server), list);
+                char *local_str="127.0.0.1";
+                if (strncmp(local_str,rpc_trans->myinfo.identifier,strlen(local_str)) != 0) {
+                    server = list_entry(server->list.next, typeof(*server), list);
+                }
             }
             ctx->cmd_args.curr_server = server;
             ctx->cmd_args.volfile_server = server->volfile_server;


### PR DESCRIPTION
when use localhost(127.0.0.1)  addr mount a volume,  if glusterd is down ,client not change  connect other glusterd server , because socket bind  127.0.0.1 can not connect other node addr success . so change volume server round-roubin  filter  127.0.0.1 

Fixes: #4442

